### PR TITLE
Fixing problem with Fieldmap end point

### DIFF
--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -53,6 +53,17 @@ Job Triggered
        Would be nice to be able to just make one call that returns
        all this info.
        
+# Issues
+
+## 9-5-2018 
+- during development randomly lost contact with the database.  Got the following
+  error:
+  
+```  
+Exception Type: OperationalError at /api/v1/sources/
+Exception Value: could not translate host name "postgresql" to address: No address associated with hostname
+```
+        
   
 
 # Theoretical Datamodel

--- a/src/backend/app_kirk_rest/api/serializers.py
+++ b/src/backend/app_kirk_rest/api/serializers.py
@@ -38,14 +38,15 @@ class DestinationsSerializer(serializers.ModelSerializer):
 
 class FieldmapSerializer(serializers.ModelSerializer):
 
-    # owner = serializers.ReadOnlyField(source='owner.username') # ADD THIS LINE
-
+    whoCreated = serializers.ReadOnlyField(source='whoCreated.username') # ADD THIS LINE
+    whoUpdated = serializers.ReadOnlyField(source='whoUpdated.username') # ADD THIS LINE
+    
     class Meta:
         """Meta class to map serializer's fields with the model fields."""
         model = FieldMap
         fields = ('fieldMapId', 'jobid', 'sourceColumnName', 'destColumnName', \
                   'fmeColumnType', 'whoCreated', 'whenCreated', 'whoUpdated',
-                  'whoUpdated'
+                  'whenUpdated'
                   )
         read_only_fields = ('fieldMapId',)
 

--- a/src/backend/app_kirk_rest/api/views.py
+++ b/src/backend/app_kirk_rest/api/views.py
@@ -145,7 +145,9 @@ class FieldMapView(generics.ListCreateAPIView):
 
     def perform_create(self, serializer):
         """Save the post data when creating a new bucketlist."""
-        serializer.save()
+        #serializer.save()
+        serializer.save(whoCreated=self.request.user, whoUpdated=self.request.user)
+
 
 
 class FieldMapDetailsView(generics.RetrieveUpdateDestroyAPIView):


### PR DESCRIPTION
Field map end point was not autopopulating the 'whocreated' and
'whoupdated' fields properly.  This is somewhat resolved.  likely in the
future need to figure out how ot update only whoupdated when record is
updated vs created.